### PR TITLE
ref: Translate contact page strings to Spanish

### DIFF
--- a/src/features/contact/components/ClinicInformationCards/ClinicInformationCards.tsx
+++ b/src/features/contact/components/ClinicInformationCards/ClinicInformationCards.tsx
@@ -35,7 +35,7 @@ export const ClinicInformationCards: React.FC = () => {
     {
       id: 'address',
       icon: <EnvironmentOutlined />,
-      title: 'Location',
+      title: 'Ubicación',
       content: (
         <Space direction="vertical" size={4}>
           <Text strong className={styles.clinicName}>
@@ -48,7 +48,7 @@ export const ClinicInformationCards: React.FC = () => {
     {
       id: 'hours',
       icon: <ClockCircleOutlined />,
-      title: 'Hours of Operation',
+      title: 'Horario de Atención',
       content: (
         <Space direction="vertical" size={4}>
           {clinicInformation.schedule.map((scheduleItem, index) => {
@@ -70,7 +70,7 @@ export const ClinicInformationCards: React.FC = () => {
     {
       id: 'phone',
       icon: <PhoneOutlined />,
-      title: 'Phone',
+      title: 'Teléfono',
       content: (
         <Link href={`tel:${clinicInformation.contact.phones[0]}`} className={styles.contactLink}>
           {clinicInformation.contact.phones[0]}
@@ -80,7 +80,7 @@ export const ClinicInformationCards: React.FC = () => {
     {
       id: 'email',
       icon: <MailOutlined />,
-      title: 'Email',
+      title: 'Correo Electrónico',
       content: (
         <Link href={`mailto:${clinicInformation.contact.email}`} className={styles.contactLink}>
           {clinicInformation.contact.email}
@@ -92,7 +92,7 @@ export const ClinicInformationCards: React.FC = () => {
   return (
     <div className={styles.infoCardsContainer}>
       <Title level={2} className={styles.sectionTitle}>
-        Clinic Information
+        Información de la Clínica
       </Title>
       <Space direction="vertical" size="middle" className={styles.cardsGrid}>
         {infoCards.map((card) => (

--- a/src/features/contact/components/LocationMap/LocationMap.tsx
+++ b/src/features/contact/components/LocationMap/LocationMap.tsx
@@ -74,10 +74,10 @@ export const LocationMap: React.FC = () => {
 
       <div className={styles.buttonGroup}>
         <Button type="default" size="large" onClick={handleOpenGoogleMaps} className={styles.navButton}>
-          Open in Google Maps
+          Abrir en Google Maps
         </Button>
         <Button type="primary" size="large" onClick={handleOpenWaze} className={styles.navButton}>
-          Open in Waze
+          Abrir en Waze
         </Button>
       </div>
     </div>

--- a/src/features/contact/components/OperationalHours/OperationalHours.tsx
+++ b/src/features/contact/components/OperationalHours/OperationalHours.tsx
@@ -17,7 +17,7 @@ export const OperationalHours: React.FC = () => {
 
   return (
     <div className={styles.operationalHours}>
-      <h2 className={styles.title}>Operational Hours</h2>
+      <h2 className={styles.title}>Horario de Atención</h2>
 
       <div className={styles.scheduleList}>
         {schedule.map((item, index) => (


### PR DESCRIPTION
# 🚀 Pull Request

## 📋 Description

Please include a summary of the change.

Localize contact-related UI text to Spanish across components. Updated ClinicInformationCards (section title and card titles: Location, Hours of Operation, Phone, Email -> Ubicación, Horario de Atención, Teléfono, Correo Electrónico), LocationMap (map navigation buttons -> Abrir en Google Maps / Abrir en Waze), and OperationalHours (title -> Horario de Atención). Functionality unchanged; purely text translations for localization.